### PR TITLE
Fix: Resolve issue #4 – Add orm_mode=True to Item Pydantic schema

### DIFF
--- a/app/schemas/item.py
+++ b/app/schemas/item.py
@@ -9,3 +9,6 @@ class ItemCreate(ItemBase):
 
 class ItemSchema(ItemBase):
     id: int
+
+class Config:
+        orm_mode = True


### PR DESCRIPTION
This PR fixes Issue #4 by updating the `Item` Pydantic schema to enable ORM compatibility.

## Changes Made
- Added `orm_mode = True` in the `Config` class of `Item` schema (app/schemas/item.py)

## Why This Fix?
Without `orm_mode`, FastAPI cannot properly serialize SQLAlchemy models into the Pydantic schema, which can cause response validation errors.  
This ensures DB models are correctly returned in API responses.

Closes #4